### PR TITLE
feat: Add support for other AWS partitions (cn, us-gov, etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - update MySQL instance to use T3 instance type
 - upgrade `cdk_ecr_deployment` version to fix the deprecated `go1.x` lambda runtime
+- add support for other AWS partitions
 
 ### **Removed**
 

--- a/modules/fmops/sagemaker-jumpstart-fm-endpoint/lib/sagemaker-jumpstart-fm-endpoint-stack.ts
+++ b/modules/fmops/sagemaker-jumpstart-fm-endpoint/lib/sagemaker-jumpstart-fm-endpoint-stack.ts
@@ -38,7 +38,7 @@ export class SagemakerJumpStartFmEndpointStack extends cdk.Stack {
             new PolicyStatement({
               effect: Effect.ALLOW,
               actions: ["s3:GetObject", "s3:ListBucket"],
-              resources: ["arn:aws:s3:::jumpstart-*"],
+              resources: [`arn:${this.partition}:s3:::jumpstart-*`],
             }),
             new PolicyStatement({
               effect: Effect.ALLOW,

--- a/modules/sagemaker/sagemaker-custom-kernel/modulestack.yaml
+++ b/modules/sagemaker/sagemaker-custom-kernel/modulestack.yaml
@@ -36,12 +36,12 @@ Resources:
               - "sagemaker:DescribeDomain"
               - "sagemaker:UpdateDomain"
             Resource:
-              - !Sub "arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:domain/${StudioDomainId}"
+              - !Sub "arn:${AWS::Partition}:sagemaker:${AWS::Region}:${AWS::AccountId}:domain/${StudioDomainId}"
           - Effect: Allow
             Action:
               - "iam:PassRole"
             Resource:
-              - !Sub "arn:aws:iam::${AWS::AccountId}:role/${ProjectName}-${DeploymentName}-${ModuleName}-image-role"
+              - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${ProjectName}-${DeploymentName}-${ModuleName}-image-role"
               - !Ref StudioExecutionRoleArn
           - Action:
               - "ecr:*LayerUpload"
@@ -55,7 +55,7 @@ Resources:
               - "ecr:UploadLayerPart"
             Effect: Allow
             Resource:
-              - !Sub "arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/${ECRRepoName}"
+              - !Sub "arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/${ECRRepoName}"
         Version: 2012-10-17
       PolicyName: "mlops-modulespecific-policy"
       Roles: [!Ref RoleName]

--- a/modules/sagemaker/sagemaker-endpoint/stack.py
+++ b/modules/sagemaker/sagemaker-endpoint/stack.py
@@ -94,7 +94,7 @@ class DeployEndpointStack(Stack):
                         "kms:Decrypt",
                         "kms:DescribeKey",
                     ],
-                    resources=[f"arn:aws:kms:{self.region}:{self.account}:key/*"],
+                    resources=[f"arn:{self.partition}:kms:{self.region}:{self.account}:key/*"],
                 ),
             )
 

--- a/modules/sagemaker/sagemaker-studio/helper_constructs/sm_roles.py
+++ b/modules/sagemaker/sagemaker-studio/helper_constructs/sm_roles.py
@@ -32,7 +32,7 @@ class SMRoles(Construct):
                 iam.PolicyStatement(
                     effect=iam.Effect.ALLOW,
                     actions=["iam:PassRole"],
-                    resources=[f"arn:aws:iam::{Aws.ACCOUNT_ID}:role/cdk*"],
+                    resources=[f"arn:{Aws.PARTITION}:iam::{Aws.ACCOUNT_ID}:role/cdk*"],
                 ),
             ],
         )
@@ -173,21 +173,21 @@ class SMRoles(Construct):
                         "s3:GetBucketLocation",
                     ],
                     resources=[
-                        "arn:aws:s3:::{}*/*".format(s3_bucket_prefix),
-                        "arn:aws:s3:::{}*".format(s3_bucket_prefix),
-                        "arn:aws:s3:::cdk*/*",
-                        "arn:aws:s3:::cdk*",
-                        "arn:aws:s3:::sagemaker*",
-                        "arn:aws:s3:::sagemaker*/*",
+                        f"arn:{Aws.PARTITION}:s3:::{s3_bucket_prefix}*/*",
+                        f"arn:{Aws.PARTITION}:s3:::{s3_bucket_prefix}*",
+                        f"arn:{Aws.PARTITION}:s3:::cdk*/*",
+                        f"arn:{Aws.PARTITION}:s3:::cdk*",
+                        f"arn:{Aws.PARTITION}:s3:::sagemaker*",
+                        f"arn:{Aws.PARTITION}:s3:::sagemaker*/*",
                     ],
                 ),
                 iam.PolicyStatement(
                     effect=iam.Effect.ALLOW,
                     actions=["s3:ListBucket"],
                     resources=[
-                        "arn:aws:s3:::{}*".format(s3_bucket_prefix),
-                        "arn:aws:s3:::cdk*",
-                        "arn:aws:s3:::sagemaker*",
+                        f"arn:{Aws.PARTITION}:s3:::{s3_bucket_prefix}*",
+                        f"arn:{Aws.PARTITION}:s3:::cdk*",
+                        f"arn:{Aws.PARTITION}:s3:::sagemaker*",
                     ],
                 ),
                 iam.PolicyStatement(

--- a/modules/sagemaker/sagemaker-studio/modulestack.yaml
+++ b/modules/sagemaker/sagemaker-studio/modulestack.yaml
@@ -30,8 +30,8 @@ Resources:
               - "elasticfilesystem:DeleteMountTarget"
               - "elasticfilesystem:DeleteFileSystem"
             Resource:
-              - !Sub "arn:aws:elasticfilesystem:${AWS::Region}:${AWS::AccountId}:file-system/*"
-              - !Sub "arn:aws:elasticfilesystem:${AWS::Region}:${AWS::AccountId}:access-point/*"
+              - !Sub "arn:${AWS::Partition}:elasticfilesystem:${AWS::Region}:${AWS::AccountId}:file-system/*"
+              - !Sub "arn:${AWS::Partition}:elasticfilesystem:${AWS::Region}:${AWS::AccountId}:access-point/*"
           - Effect: Allow
             Action:
               - "elasticfilesystem:Describe*"

--- a/modules/sagemaker/sagemaker-templates-service-catalog/templates/multi_account_basic/pipeline_constructs/build_pipeline_construct.py
+++ b/modules/sagemaker/sagemaker-templates-service-catalog/templates/multi_account_basic/pipeline_constructs/build_pipeline_construct.py
@@ -101,7 +101,7 @@ class BuildPipelineConstruct(Construct):
                             "kms:DescribeKey",
                         ],
                         effect=iam.Effect.ALLOW,
-                        resources=[f"arn:aws:kms:{Aws.REGION}:{Aws.ACCOUNT_ID}:key/*"],
+                        resources=[f"arn:{Aws.PARTITION}:kms:{Aws.REGION}:{Aws.ACCOUNT_ID}:key/*"],
                     ),
                 ]
             ),

--- a/modules/sagemaker/sagemaker-templates-service-catalog/templates/multi_account_basic/pipeline_constructs/deploy_pipeline_construct.py
+++ b/modules/sagemaker/sagemaker-templates-service-catalog/templates/multi_account_basic/pipeline_constructs/deploy_pipeline_construct.py
@@ -91,7 +91,7 @@ class DeployPipelineConstruct(Construct):
                     "kms:DescribeKey",
                 ],
                 effect=iam.Effect.ALLOW,
-                resources=[f"arn:aws:kms:{Aws.REGION}:{Aws.ACCOUNT_ID}:key/*"],
+                resources=[f"arn:{Aws.PARTITION}:kms:{Aws.REGION}:{Aws.ACCOUNT_ID}:key/*"],
             ),
         )
 

--- a/modules/sagemaker/sagemaker-templates-service-catalog/templates/multi_account_basic/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
+++ b/modules/sagemaker/sagemaker-templates-service-catalog/templates/multi_account_basic/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
@@ -97,7 +97,7 @@ class DeployEndpointStack(Stack):
                             "kms:DescribeKey",
                         ],
                         effect=iam.Effect.ALLOW,
-                        resources=[f"arn:aws:kms:{Aws.REGION}:{DEPLOYMENT_ACCOUNT}:key/*"],
+                        resources=[f"arn:{Aws.PARTITION}:kms:{Aws.REGION}:{DEPLOYMENT_ACCOUNT}:key/*"],
                     ),
                 ]
             ),

--- a/one-click-launch.yaml
+++ b/one-click-launch.yaml
@@ -13,7 +13,7 @@ Resources:
               Service: codebuild.amazonaws.com
 
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AWSCodeBuildAdminAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSCodeBuildAdminAccess
       Policies:
         - PolicyName: create
           PolicyDocument:
@@ -39,9 +39,9 @@ Resources:
               - cloudformation:DeleteStack
               - cloudformation:DeleteChangeSet
               Resource:
-              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/CDKToolkit/*
-              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/seedfarmer-*
-              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/aws-codeseeder-*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/CDKToolkit/*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/seedfarmer-*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/aws-codeseeder-*
             - Sid: IAM
               Effect: Allow
               Action:
@@ -55,8 +55,8 @@ Resources:
               - iam:getRolePolicy
               - iam:TagRole
               Resource:
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/cdk-*
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/seedfarmer-*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/seedfarmer-*
             - Sid: ECR
               Effect: Allow
               Action:
@@ -67,7 +67,7 @@ Resources:
               - ecr:PutLifecyclePolicy
               - ecr:PutImageTagMutability
               - ecr:List*
-              Resource: !Sub arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/cdk-*
+              Resource: !Sub arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/cdk-*
             - Sid: S3
               Effect: Allow
               Action:
@@ -91,14 +91,14 @@ Resources:
               - ssm:PutParameter
               - ssm:DeleteParameter
               - ssm:GetParameters
-              Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cdk-*
+              Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cdk-*
             - Sid: SecretsManager
               Effect: Allow
               Action:
               - secretsmanager:CreateSecret
               - secretsmanager:DeleteSecret
               Resource:
-              - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*"
+              - !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*"
             - Sid: Password
               Effect: Allow
               Action:
@@ -112,8 +112,8 @@ Resources:
               - es:List*
               - es:ESHttpGet
               Resource: 
-              - !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:*"
-              - !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain:*"
+              - !Sub "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:*"
+              - !Sub "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain:*"
         - PolicyName: delete
           PolicyDocument:
             Version: "2012-10-17"
@@ -130,10 +130,10 @@ Resources:
               - cloudformation:DeleteStack
               - cloudformation:DeleteChangeSet
               Resource:
-              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/CDKToolkit/*
-              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/seedfarmer-*
-              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/aws-codeseeder-*
-              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/mlops*              
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/CDKToolkit/*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/seedfarmer-*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/aws-codeseeder-*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/mlops*              
             - Sid: IAM
               Effect: Allow
               Action:
@@ -150,10 +150,10 @@ Resources:
               - iam:List*
               - iam:DeletePolicy
               Resource:
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/cdk-*
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/seedfarmer-*
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/codeseeder-*
-              - !Sub arn:aws:iam::${AWS::AccountId}:policy/codeseeder-*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/seedfarmer-*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/codeseeder-*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/codeseeder-*
             - Sid: ECR
               Effect: Allow
               Action:
@@ -164,7 +164,7 @@ Resources:
               - ecr:PutLifecyclePolicy
               - ecr:PutImageTagMutability
               - ecr:List*
-              Resource: !Sub arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/cdk-*
+              Resource: !Sub arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/cdk-*
             - Sid: S3KMS
               Effect: Allow
               Action:
@@ -194,14 +194,14 @@ Resources:
               - ssm:PutParameter
               - ssm:DeleteParameter
               - ssm:GetParameters
-              Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cdk-*
+              Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/cdk-*
             - Sid: SecretsManager
               Effect: Allow
               Action:
               - secretsmanager:CreateSecret
               - secretsmanager:DeleteSecret
               Resource:
-              - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*"
+              - !Sub "arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*"
             - Sid: Password
               Effect: Allow
               Action:
@@ -215,8 +215,8 @@ Resources:
               - es:List*
               - es:ESHttpGet
               Resource: 
-              - !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:*"
-              - !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain:*"
+              - !Sub "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:*"
+              - !Sub "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain:*"
             - Sid: S3DeleteCodeseeder
               Effect: Allow
               Action:
@@ -224,16 +224,16 @@ Resources:
               - s3:PutObject
               - s3:PutObjectAcl
               Resource: 
-              - !Sub "arn:aws:s3:::codeseeder-mlops-${AWS::AccountId}-*"
-              - !Sub "arn:aws:s3:::codeseeder-mlops-${AWS::AccountId}-*/*"
-              - "arn:aws:s3:::mlops*"
-              - "arn:aws:s3:::mlops*/*"
+              - !Sub "arn:${AWS::Partition}:s3:::codeseeder-mlops-${AWS::AccountId}-*"
+              - !Sub "arn:${AWS::Partition}:s3:::codeseeder-mlops-${AWS::AccountId}-*/*"
+              - !Sub "arn:${AWS::Partition}:s3:::mlops*"
+              - !Sub "arn:${AWS::Partition}:s3:::mlops*/*"
             - Sid: CodebuildCleanup
               Effect: Allow
               Action:
               - codebuild:DeleteProject
               Resource: 
-              - !Sub "arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/codeseeder-mlops"
+              - !Sub "arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/codeseeder-mlops"
   CreateUpdateCodeBuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
@@ -472,4 +472,4 @@ Resources:
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: arn:aws:logs:*:*:*
+            Resource: !Sub arn:${AWS::Partition}:logs:*:*:*


### PR DESCRIPTION
## Describe your changes

Adding support for other AWS partitions, such as `aws-cn` and `aws-us-gov`.

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
