### PR TITLE
fix: `sagemaker-custom-kernel` module permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 
+- update `sagemaker-custom-kernel` module IAM permissions
 - split `xgboost_abalone` and `model_deploy` project templates in `sagemaker-templates-service-catalog` module
 - add support for other AWS partitions
 - update MySQL instance to use T3 instance type

--- a/modules/sagemaker/sagemaker-custom-kernel/modulestack.yaml
+++ b/modules/sagemaker/sagemaker-custom-kernel/modulestack.yaml
@@ -17,9 +17,6 @@ Parameters:
   StudioExecutionRoleArn:
     Type: String
     Description: The name of the Sagemaker Studio IAM Role
-  ECRRepoName:
-    Type: String
-    Description: The name of the ECR repository
   StudioDomainId:
     Type: String
     Description: The id of the SageMaker Studio Domain

--- a/modules/sagemaker/sagemaker-custom-kernel/modulestack.yaml
+++ b/modules/sagemaker/sagemaker-custom-kernel/modulestack.yaml
@@ -43,19 +43,6 @@ Resources:
             Resource:
               - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${ProjectName}-${DeploymentName}-${ModuleName}-image-role"
               - !Ref StudioExecutionRoleArn
-          - Action:
-              - "ecr:*LayerUpload"
-              - "ecr:Batch*"
-              - "ecr:Create*"
-              - "ecr:Delete*"
-              - "ecr:Describe*"
-              - "ecr:Get*"
-              - "ecr:List*"
-              - "ecr:Put*"
-              - "ecr:UploadLayerPart"
-            Effect: Allow
-            Resource:
-              - !Sub "arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/${ECRRepoName}"
         Version: 2012-10-17
       PolicyName: "mlops-modulespecific-policy"
       Roles: [!Ref RoleName]


### PR DESCRIPTION
## Describe your changes
- removed ECR IAM permissions from `sagemaker-custom-kernel`'s `modulestack.yaml` as ECR deployment is handled by CDK

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
