### PR TITLE
(sagemaker templates) add bucket and model package group names as stack outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 - fixed model deploy cross-account permissions
+- added bucket and model package group names as stack outputs in the `sagemaker-templates` module
 
 ## v1.1.0
 

--- a/modules/sagemaker/sagemaker-templates-service-catalog/templates/hf_import_models/product_stack.py
+++ b/modules/sagemaker/sagemaker-templates-service-catalog/templates/hf_import_models/product_stack.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import aws_cdk
 import aws_cdk.aws_servicecatalog as servicecatalog
-from aws_cdk import Aws, Tags
+from aws_cdk import Aws, CfnOutput, Tags
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_kms as kms
 from aws_cdk import aws_s3 as s3
@@ -213,4 +213,16 @@ class Product(servicecatalog.ProductStack):
             model_package_group_name=model_package_group_name,
             hf_access_token_secret=hf_access_token_secret,
             hf_model_id=hf_model_id,
+        )
+
+        CfnOutput(
+            self,
+            "Model Bucket Name",
+            value=s3_artifact.bucket_name,
+        )
+
+        CfnOutput(
+            self,
+            "Model Package Group Name",
+            value=model_package_group_name,
         )

--- a/modules/sagemaker/sagemaker-templates-service-catalog/templates/xgboost_abalone/product_stack.py
+++ b/modules/sagemaker/sagemaker-templates-service-catalog/templates/xgboost_abalone/product_stack.py
@@ -9,7 +9,7 @@ import aws_cdk.aws_s3 as s3
 import aws_cdk.aws_s3_assets as s3_assets
 import aws_cdk.aws_sagemaker as sagemaker
 import aws_cdk.aws_servicecatalog as servicecatalog
-from aws_cdk import Aws, CfnParameter, CfnTag, RemovalPolicy, Tags
+from aws_cdk import Aws, CfnOutput, CfnParameter, CfnTag, RemovalPolicy, Tags
 from constructs import Construct
 
 from templates.xgboost_abalone.pipeline_constructs.build_pipeline_construct import (
@@ -236,4 +236,16 @@ class Product(servicecatalog.ProductStack):
             model_bucket=model_bucket,
             pipeline_artifact_bucket=pipeline_artifact_bucket,
             repo_asset=build_app_asset,
+        )
+
+        CfnOutput(
+            self,
+            "Model Bucket Name",
+            value=model_bucket.bucket_name,
+        )
+
+        CfnOutput(
+            self,
+            "Model Package Group Name",
+            value=model_package_group_name,
         )


### PR DESCRIPTION
## Describe your changes

- Sagemaker templates: add bucket and model package group names as stack outputs
  - This should make those values easier to find for customers using the `deploy` template

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
