### PR TITLE
chore: rename seedfarmer project name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### **Changed**
 - fixed model deploy cross-account permissions
 - added bucket and model package group names as stack outputs in the `sagemaker-templates` module
+- rename seedfarmer project name to `aiops`
 
 ## v1.1.0
 

--- a/seedfarmer.yaml
+++ b/seedfarmer.yaml
@@ -1,3 +1,3 @@
-project: mlops
+project: aiops
 description: This is for local testing - intended for contributions
 #projectPolicyPath: <some relative path to this file>


### PR DESCRIPTION
## Describe your changes
- Renames seedfarmer project name `mlops` -> `aiops`

## Checklist before requesting a review

- [X] I updated `CHANGELOG.MD` with a description of my changes
- [X] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [X] If the change was to a module, I have added thorough tests
- [X] If the change was to a module, I have added/updated the module's README.md
- [X] If a module was added, I added a reference to the module to the repository's README.md
- [X] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
