### PR TITLE
chore: create s3 buckets with destroy removal policy

### DIFF
--- a/manifests/mlflow-experiments-tracking/storage-modules.yaml
+++ b/manifests/mlflow-experiments-tracking/storage-modules.yaml
@@ -12,7 +12,7 @@ parameters:
   - name: encryption-type
     value: SSE
   - name: retention-type
-    value: RETAIN
+    value: DESTROY
 ---
 name: mlflow-mysql
 path: git::https://github.com/awslabs/idf-modules.git//modules/database/rds?ref=release/1.4.0&depth=1

--- a/manifests/mlops-sagemaker-multiacc/storage-modules.yaml
+++ b/manifests/mlops-sagemaker-multiacc/storage-modules.yaml
@@ -12,4 +12,4 @@ parameters:
   - name: encryption-type
     value: SSE
   - name: retention-type
-    value: RETAIN
+    value: DESTROY

--- a/manifests/storage-modules.yaml
+++ b/manifests/storage-modules.yaml
@@ -19,7 +19,7 @@ parameters:
   - name: encryption-type
     value: SSE
   - name: retention-type
-    value: RETAIN
+    value: DESTROY
 ---
 name: mlflow-mysql
 path: git::https://github.com/awslabs/idf-modules.git//modules/database/rds?ref=release/1.7.0&depth=1


### PR DESCRIPTION
## Describe your changes
- Updating manifests to use `DESTROY` for bucket retention type

**If retention is desired for the published manifests, i can look into adding an additional cleanup mechanism to get integ tests passing**

## Checklist before requesting a review

- [ ] I updated `CHANGELOG.MD` with a description of my changes
- [ ] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [ ] If the change was to a module, I have added thorough tests
- [ ] If the change was to a module, I have added/updated the module's README.md
- [ ] If a module was added, I added a reference to the module to the repository's README.md
- [ ] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
