### PR TITLE
chore: Refactor `sagemaker-endpoint` to use pydantic for inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### **Changed**
 - fixed model deploy cross-account permissions
 - added bucket and model package group names as stack outputs in the `sagemaker-templates` module
-- refactor inputs for `mlflow-fargate` and `mlflow-image` 
-- refactor inputs for `sagemaker-studio` 
+- refactor inputs for the following modules to use Pydantic:
+  - `mlflow-fargate`
+  - `mlflow-image` 
+  - `sagemaker-studio`
+  - `sagemaker-endpoint`
 - rename seedfarmer project name to `aiops`
 - chore: adding some missing auto_delete attributes
 - chore: Add `auto_delete` to `mlflow-fargate` elb access logs bucket

--- a/modules/sagemaker/sagemaker-endpoint/coverage.ini
+++ b/modules/sagemaker/sagemaker-endpoint/coverage.ini
@@ -1,3 +1,0 @@
-[run]
-omit =
-    tests/*

--- a/modules/sagemaker/sagemaker-endpoint/pyproject.toml
+++ b/modules/sagemaker/sagemaker-endpoint/pyproject.toml
@@ -23,7 +23,6 @@ fixable = ["ALL"]
 [tool.mypy]
 python_version = "3.8"
 strict = true
-ignore_missing_imports = true
 disallow_untyped_decorators = false
 exclude = "codeseeder.out/|example/|tests/"
 warn_unused_ignores = false

--- a/modules/sagemaker/sagemaker-endpoint/requirements.txt
+++ b/modules/sagemaker/sagemaker-endpoint/requirements.txt
@@ -2,3 +2,4 @@ aws-cdk-lib==2.126.0
 cdk-nag==2.28.27
 boto3==1.34.35
 pydantic==2.7.2
+pydantic-settings==2.2.1

--- a/modules/sagemaker/sagemaker-endpoint/requirements.txt
+++ b/modules/sagemaker/sagemaker-endpoint/requirements.txt
@@ -1,4 +1,4 @@
 aws-cdk-lib==2.126.0
 cdk-nag==2.28.27
-yamldataclassconfig==1.5.0
 boto3==1.34.35
+pydantic==2.7.2

--- a/modules/sagemaker/sagemaker-endpoint/settings.py
+++ b/modules/sagemaker/sagemaker-endpoint/settings.py
@@ -1,0 +1,96 @@
+"""Defines the stack settings."""
+
+from abc import ABC
+from typing import Dict, List, Optional
+
+from pydantic import Field, computed_field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class CdkBaseSettings(BaseSettings, ABC):
+    """Defines common configuration for settings."""
+
+    model_config = SettingsConfigDict(
+        case_sensitive=False,
+        env_nested_delimiter="__",
+        protected_namespaces=(),
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+
+class ModuleSettings(CdkBaseSettings):
+    """Seedfarmer Parameters.
+
+    These parameters are required for the module stack.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="SEEDFARMER_PARAMETER_")
+
+    vpc_id: str
+    subnet_ids: List[str]
+
+    sagemaker_project_id: Optional[str] = Field(default=None)
+    sagemaker_project_name: Optional[str] = Field(default=None)
+    model_package_arn: Optional[str] = Field(default=None)
+    model_package_group_name: Optional[str] = Field(default=None)
+    model_execution_role_arn: Optional[str] = Field(default=None)
+    model_artifacts_bucket_arn: Optional[str] = Field(default=None)
+    ecr_repo_arn: Optional[str] = Field(default=None)
+    variant_name: str = Field(default="AllTraffic")
+
+    initial_instance_count: int = Field(default=1)
+    initial_variant_weight: int = Field(default=1)
+    instance_type: str = Field(default="ml.m4.xlarge")
+    managed_instance_scaling: bool = Field(default=False)
+    scaling_min_instance_count: int = Field(default=1)
+    scaling_max_instance_count: int = Field(default=10)
+
+    tags: Optional[Dict[str, str]] = Field(default=None)
+
+    @model_validator(mode="after")
+    def check_model_package(self) -> "ModuleSettings":
+        if not self.model_package_arn and not self.model_package_group_name:
+            raise ValueError("Parameter model-package-arn or model-package-group-name is required")
+
+        return self
+
+
+class SeedFarmerSettings(CdkBaseSettings):
+    """Seedfarmer Settings.
+
+    These parameters comes from seedfarmer by default.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="SEEDFARMER_")
+
+    project_name: str = Field(default="")
+    deployment_name: str = Field(default="")
+    module_name: str = Field(default="")
+
+    @computed_field  # type: ignore
+    @property
+    def app_prefix(self) -> str:
+        """Application prefix."""
+        prefix = "-".join([self.project_name, self.deployment_name, self.module_name])
+        return prefix
+
+
+class CDKSettings(CdkBaseSettings):
+    """CDK Default Settings.
+
+    These parameters comes from AWS CDK by default.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="CDK_DEFAULT_")
+
+    account: str
+    region: str
+
+
+class ApplicationSettings(CdkBaseSettings):
+    """Application settings."""
+
+    seedfarmer_settings: SeedFarmerSettings = Field(default_factory=SeedFarmerSettings)
+    module_settings: ModuleSettings = Field(default_factory=ModuleSettings)
+    cdk_settings: CDKSettings = Field(default_factory=CDKSettings)

--- a/modules/sagemaker/sagemaker-endpoint/tests/test_app.py
+++ b/modules/sagemaker/sagemaker-endpoint/tests/test_app.py
@@ -1,33 +1,40 @@
 import os
 import sys
+from unittest import mock
 
 import pytest
+from pydantic import ValidationError
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="function", autouse=True)
 def stack_defaults():
-    os.environ["SEEDFARMER_PROJECT_NAME"] = "test-project"
-    os.environ["SEEDFARMER_DEPLOYMENT_NAME"] = "test-deployment"
-    os.environ["SEEDFARMER_MODULE_NAME"] = "test-module"
-    os.environ["CDK_DEFAULT_ACCOUNT"] = "111111111111"
-    os.environ["CDK_DEFAULT_REGION"] = "us-east-1"
+    with mock.patch.dict(os.environ, {}, clear=True):
+        os.environ["SEEDFARMER_PROJECT_NAME"] = "test-project"
+        os.environ["SEEDFARMER_DEPLOYMENT_NAME"] = "test-deployment"
+        os.environ["SEEDFARMER_MODULE_NAME"] = "test-module"
 
-    os.environ["SEEDFARMER_PARAMETER_VPC_ID"] = "vpc-12345"
-    os.environ["SEEDFARMER_PARAMETER_SAGEMAKER_PROJECT_ID"] = "12345"
-    os.environ["SEEDFARMER_PARAMETER_SAGEMAKER_PROJECT_NAME"] = "sagemaker-project"
-    os.environ["SEEDFARMER_PARAMETER_MODEL_PACKAGE_ARN"] = "example-arn"
+        os.environ["CDK_DEFAULT_ACCOUNT"] = "111111111111"
+        os.environ["CDK_DEFAULT_REGION"] = "us-east-1"
 
-    # Unload the app import so that subsequent tests don't reuse
-    if "app" in sys.modules:
-        del sys.modules["app"]
+        os.environ["SEEDFARMER_PARAMETER_VPC_ID"] = "vpc-12345"
+        os.environ["SEEDFARMER_PARAMETER_SUBNET_IDS"] = '["subnet-1","subnet-2","subnet-3"]'
+        os.environ["SEEDFARMER_PARAMETER_SAGEMAKER_PROJECT_ID"] = "12345"
+        os.environ["SEEDFARMER_PARAMETER_SAGEMAKER_PROJECT_NAME"] = "sagemaker-project"
+        os.environ["SEEDFARMER_PARAMETER_MODEL_PACKAGE_ARN"] = "example-arn"
+
+        # Unload the app import so that subsequent tests don't reuse
+        if "app" in sys.modules:
+            del sys.modules["app"]
+
+        yield None
 
 
-def test_app(stack_defaults):
+def test_app() -> None:
     import app  # noqa: F401
 
 
-def test_vpc_id(stack_defaults):
+def test_vpc_id() -> None:
     del os.environ["SEEDFARMER_PARAMETER_VPC_ID"]
 
-    with pytest.raises(Exception, match="Missing input parameter vpc-id"):
+    with pytest.raises(ValidationError):
         import app  # noqa: F401

--- a/modules/sagemaker/sagemaker-endpoint/tests/test_stack.py
+++ b/modules/sagemaker/sagemaker-endpoint/tests/test_stack.py
@@ -10,14 +10,17 @@ from aws_cdk.assertions import Annotations, Match, Template
 from botocore.stub import Stubber
 
 
-@pytest.fixture(scope="function")
-def stack_defaults() -> None:
-    os.environ["CDK_DEFAULT_ACCOUNT"] = "111111111111"
-    os.environ["CDK_DEFAULT_REGION"] = "us-east-1"
+@pytest.fixture(scope="function", autouse=True)
+def stack_defaults():
+    with mock.patch.dict(os.environ, {}, clear=True):
+        os.environ["CDK_DEFAULT_ACCOUNT"] = "111111111111"
+        os.environ["CDK_DEFAULT_REGION"] = "us-east-1"
 
-    # Unload the app import so that subsequent tests don't reuse
-    if "stack" in sys.modules:
-        del sys.modules["stack"]
+        # Unload the app import so that subsequent tests don't reuse
+        if "stack" in sys.modules:
+            del sys.modules["stack"]
+
+        yield
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Describe your changes

Refactor `sagemaker-endpoint` to use pydantic for inputs.

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
