### PR TITLE
chore: remove explicit module manifest account/region mappings 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+### **Changed**
+- remove explicit module manifest account/region mappings from `fmops-qna-rag`
+
 ## v1.2.0
 
 ### **Added**

--- a/manifests/fmops-qna-rag/networking-modules.yaml
+++ b/manifests/fmops-qna-rag/networking-modules.yaml
@@ -1,6 +1,5 @@
 name: networking
 path: git::https://github.com/awslabs/idf-modules.git//modules/network/basic-cdk?ref=release/1.3.0&depth=1
-targetAccount: primary
 parameters:
   - name: internet-accessible
     value: True

--- a/manifests/fmops-qna-rag/storage-modules.yaml
+++ b/manifests/fmops-qna-rag/storage-modules.yaml
@@ -1,8 +1,6 @@
 ---
 name: opensearch
 path: git::https://github.com/awslabs/idf-modules.git//modules/storage/opensearch?ref=release/1.7.0&depth=1
-targetAccount: primary
-targetRegion: us-east-1
 parameters:
   - name: encryption-type
     value: SSE


### PR DESCRIPTION
### Changes
- remove explicit module manifest account/region mappings from `fmops-qna-rag`

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
