### PR TITLE
fix: Inputs for bedrock-finetuning module not working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -375,7 +375,6 @@ fabric.properties
 # cdk
 cdk.out
 cdk.context.json
-cdk.json
 
 # codeseeder
 codeseeder.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - changed ECR encryption to KMS_MANAGED
 - changed encryption for each bucket to KMS_MANAGED
 - refactor `airflow-dags` module to use Pydantic
+- fix inputs for `bedrock-finetuning` module not working
 
 ## v1.2.0
 

--- a/modules/fmops/bedrock-finetuning/bin/bedrock-finetuning.ts
+++ b/modules/fmops/bedrock-finetuning/bin/bedrock-finetuning.ts
@@ -16,8 +16,10 @@ const vpcId: string | undefined = process.env.SEEDFARMER_PARAMETER_VPC_ID;
 const subnetIds: string[] = JSON.parse(
   process.env.SEEDFARMER_PARAMETER_SUBNET_IDS || ("[]" as string),
 );
-const bedrockBaseModelID: string = process.env.BEDROCK_BASE_MODEL_ID!;
-const bucketName: string = process.env.BUCKET_NAME!;
+const bedrockBaseModelID: string = process.env.SEEDFARMER_PARAMETER_BEDROCK_BASE_MODEL_ID!;
+const bucketName: string | undefined = process.env.SEEDFARMER_PARAMETER_BUCKET_NAME;
+
+
 const app = new cdk.App();
 const stack = new AmazonBedrockFinetuningStack(
   app,

--- a/modules/fmops/bedrock-finetuning/bin/bedrock-finetuning.ts
+++ b/modules/fmops/bedrock-finetuning/bin/bedrock-finetuning.ts
@@ -16,9 +16,10 @@ const vpcId: string | undefined = process.env.SEEDFARMER_PARAMETER_VPC_ID;
 const subnetIds: string[] = JSON.parse(
   process.env.SEEDFARMER_PARAMETER_SUBNET_IDS || ("[]" as string),
 );
-const bedrockBaseModelID: string = process.env.SEEDFARMER_PARAMETER_BEDROCK_BASE_MODEL_ID!;
-const bucketName: string | undefined = process.env.SEEDFARMER_PARAMETER_BUCKET_NAME;
-
+const bedrockBaseModelID: string =
+  process.env.SEEDFARMER_PARAMETER_BEDROCK_BASE_MODEL_ID!;
+const bucketName: string | undefined =
+  process.env.SEEDFARMER_PARAMETER_BUCKET_NAME;
 
 const app = new cdk.App();
 const stack = new AmazonBedrockFinetuningStack(

--- a/modules/fmops/bedrock-finetuning/cdk.json
+++ b/modules/fmops/bedrock-finetuning/cdk.json
@@ -1,3 +1,3 @@
 {
-    "app": "npx ts-node --prefer-ts-exts bin/bedrock-finetuning.ts"
+  "app": "npx ts-node --prefer-ts-exts bin/bedrock-finetuning.ts"
 }

--- a/modules/fmops/bedrock-finetuning/cdk.json
+++ b/modules/fmops/bedrock-finetuning/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "npx ts-node --prefer-ts-exts bin/bedrock-finetuning.ts"
+}

--- a/modules/fmops/bedrock-finetuning/deployspec.yaml
+++ b/modules/fmops/bedrock-finetuning/deployspec.yaml
@@ -3,18 +3,18 @@ deploy:
   phases:
     install:
       commands:
-        - npm install -g aws-cdk@2.130.0
+        - npm install -g aws-cdk@2.138.0
         - npm install
     build:
       commands:
         - env
-        - cdk deploy --require-approval never --progress events --app "npx ts-node --prefer-ts-exts bin/bedrock-finetuning.ts"
+        - cdk deploy --require-approval never --progress events
 destroy:
   phases:
     install:
       commands:
-        - npm install -g aws-cdk@2.130.0
+        - npm install -g aws-cdk@2.138.0
         - npm install
     build:
       commands:
-        - cdk destroy --force --app "npx ts-node --prefer-ts-exts bin/bedrock-finetuning.ts"
+        - cdk destroy --force


### PR DESCRIPTION
## Describe your changes
- The inputs `BEDROCK_BASE_MODEL_ID` and `BUCKET_NAME` were not being read properly
- Also added a `cdk.json` file to clean up the deployspec command

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
