### PR TITLE
fix: missing PRIMARY_ACCOUNT env var for 1-click launch template

### DIFF
--- a/one-click-launch.yaml
+++ b/one-click-launch.yaml
@@ -249,11 +249,13 @@ Resources:
         EnvironmentVariables:
           - Name: AWS_ACCOUNT_ID
             Value: !Ref AWS::AccountId
-          - Name: PRIMARY_ACCOUNT
-            Value: !Ref AWS::AccountId
           - Name: AWS_REGION
             Value: !Ref AWS::Region
           - Name: AWS_DEFAULT_REGION
+            Value: !Ref AWS::Region
+          - Name: PRIMARY_ACCOUNT
+            Value: !Ref AWS::AccountId
+          - Name: PRIMARY_REGION
             Value: !Ref AWS::Region
           - Name: ROLE_ARN
             Value: !GetAtt CodeBuildRole.Arn


### PR DESCRIPTION
## Describe your changes

- add missing `PRIMARY_ACCOUNT` env var for 1-click launch template

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
