### PR TITLE
Use add_dependency instead of deprecated add_depends_on.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix inputs for `bedrock-finetuning` module not working
 - add `retention-type` argument for the bucket in the `bedrock-finetuning` module
 - fix broken dependencies for `examples/airflow-dags`
+- Use `add_dependency` to avoid deprecation warnings from CDK.
 
 ## v1.2.0
 

--- a/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/data_quality_construct.py
+++ b/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/data_quality_construct.py
@@ -99,4 +99,4 @@ class DataQualityConstruct(Construct):
             ),
             monitoring_schedule_name=f"{endpoint_name}-data-quality",
         )
-        data_quality_monitor_schedule.add_depends_on(data_quality_job_definition)
+        data_quality_monitor_schedule.add_dependency(data_quality_job_definition)

--- a/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/model_bias_construct.py
+++ b/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/model_bias_construct.py
@@ -114,4 +114,4 @@ class ModelBiasConstruct(Construct):
             ),
             monitoring_schedule_name=f"{endpoint_name}-model-bias",
         )
-        model_bias_monitor_schedule.add_depends_on(model_bias_job_definition)
+        model_bias_monitor_schedule.add_dependency(model_bias_job_definition)

--- a/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/model_explainability_construct.py
+++ b/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/model_explainability_construct.py
@@ -108,4 +108,4 @@ class ModelExplainabilityConstruct(Construct):
             ),
             monitoring_schedule_name=f"{endpoint_name}-model-explainability",
         )
-        model_explainability_monitor_schedule.add_depends_on(model_explainability_job_definition)
+        model_explainability_monitor_schedule.add_dependency(model_explainability_job_definition)

--- a/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/model_quality_construct.py
+++ b/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/model_quality_construct.py
@@ -108,4 +108,4 @@ class ModelQualityConstruct(Construct):
             ),
             monitoring_schedule_name=f"{endpoint_name}-model-quality",
         )
-        model_quality_monitor_schedule.add_depends_on(model_quality_job_definition)
+        model_quality_monitor_schedule.add_dependency(model_quality_job_definition)

--- a/modules/sagemaker/sagemaker-templates-service-catalog/templates/model_deploy/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
+++ b/modules/sagemaker/sagemaker-templates-service-catalog/templates/model_deploy/seed_code/deploy_app/deploy_endpoint/deploy_endpoint_stack.py
@@ -215,7 +215,7 @@ class DeployEndpointStack(Stack):
             ],
         )
 
-        endpoint_config.add_depends_on(model)
+        endpoint_config.add_dependency(model)
 
         # Sagemaker Endpoint
         endpoint_name = f"{MODEL_PACKAGE_GROUP_NAME}-{id}-endpoint"
@@ -227,6 +227,6 @@ class DeployEndpointStack(Stack):
             endpoint_name=endpoint_name,
         )
 
-        endpoint.add_depends_on(endpoint_config)
+        endpoint.add_dependency(endpoint_config)
 
         self.endpoint = endpoint


### PR DESCRIPTION
## Describe your changes

`add_depends_on` which was used in the SageMaker model monitoring and service catalog modules is deprecated -- `add_dependency` should be used instead: https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk/CfnResource.html#aws_cdk.CfnResource.add_depends_on

(i think the difference is that `add_dependency` can be across nested stacks, but that isn't used in this repo.)

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
