### PR TITLE
Fix redeploying SageMaker Model Monitoring module.

### DIFF
--- a/modules/sagemaker/sagemaker-model-monitoring/README.md
+++ b/modules/sagemaker/sagemaker-model-monitoring/README.md
@@ -11,6 +11,9 @@ for each monitoring job:
 * Model Bias: [ClarifyCheck step](https://docs.aws.amazon.com/sagemaker/latest/dg/build-and-manage-steps.html#step-type-clarify-check)
 * Model Explainability: [ClarifyCheck step](https://docs.aws.amazon.com/sagemaker/latest/dg/build-and-manage-steps.html#step-type-clarify-check)
 
+Note that updating parameters will require replacing resources. Deployments may be delayed until any
+running monitoring jobs complete (and the resources can be destroyed).
+
 ### Architecture
 
 ![SageMaker Model Monitoring Module Architecture](docs/_static/sagemaker-model-monitoring-module-architecture.png "SageMaker Model Monitoring Module Architecture")

--- a/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/data_quality_construct.py
+++ b/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/data_quality_construct.py
@@ -1,8 +1,9 @@
-from time import time
 from typing import Any, List
 
 from aws_cdk import aws_sagemaker as sagemaker
 from constructs import Construct
+
+from sagemaker_model_monitoring.utils import generate_unique_id
 
 
 class DataQualityConstruct(Construct):
@@ -36,7 +37,23 @@ class DataQualityConstruct(Construct):
 
         # CloudFormation doesn't seem to properly wait for the job definition name to be properly populated if we allow
         # it to autogenerate it. Generate one which will hopefully not conflict.
-        job_definition_name = f"{endpoint_name}-data-quality-{int(time())}"
+        unique_id = generate_unique_id(
+            monitor_image_uri,
+            endpoint_name,
+            model_bucket_name,
+            data_quality_checkstep_output_prefix,
+            data_quality_output_prefix,
+            kms_key_id,
+            model_monitor_role_arn,
+            security_group_id,
+            subnet_ids,
+            instance_count,
+            instance_type,
+            instance_volume_size_in_gb,
+            max_runtime_in_seconds,
+            schedule_expression,
+        )
+        job_definition_name = f"{endpoint_name}-data-quality-{unique_id}"
 
         data_quality_job_definition = sagemaker.CfnDataQualityJobDefinition(
             self,

--- a/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/model_bias_construct.py
+++ b/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/model_bias_construct.py
@@ -1,8 +1,9 @@
-from time import time
 from typing import Any, List, Optional
 
 from aws_cdk import aws_sagemaker as sagemaker
 from constructs import Construct
+
+from sagemaker_model_monitoring.utils import generate_unique_id
 
 
 class ModelBiasConstruct(Construct):
@@ -42,7 +43,29 @@ class ModelBiasConstruct(Construct):
 
         # CloudFormation doesn't seem to properly wait for the job definition name to be properly populated if we allow
         # it to autogenerate it. Generate one which will hopefully not conflict.
-        job_definition_name = f"{endpoint_name}-model-bias-{int(time())}"
+        unique_id = generate_unique_id(
+            clarify_image_uri,
+            endpoint_name,
+            model_bucket_name,
+            model_bias_checkstep_output_prefix,
+            model_bias_checkstep_analysis_config_prefix,
+            model_bias_output_prefix,
+            ground_truth_prefix,
+            kms_key_id,
+            model_monitor_role_arn,
+            security_group_id,
+            subnet_ids,
+            instance_count,
+            instance_type,
+            instance_volume_size_in_gb,
+            max_runtime_in_seconds,
+            features_attribute,
+            inference_attribute,
+            probability_attribute,
+            probability_threshold_attribute,
+            schedule_expression,
+        )
+        job_definition_name = f"{endpoint_name}-model-bias-{unique_id}"
 
         # To match the defaults in SageMaker.
         if model_bias_checkstep_analysis_config_prefix is None:

--- a/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/model_explainability_construct.py
+++ b/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/model_explainability_construct.py
@@ -1,8 +1,9 @@
-from time import time
 from typing import Any, List, Optional
 
 from aws_cdk import aws_sagemaker as sagemaker
 from constructs import Construct
+
+from sagemaker_model_monitoring.utils import generate_unique_id
 
 
 class ModelExplainabilityConstruct(Construct):
@@ -40,7 +41,27 @@ class ModelExplainabilityConstruct(Construct):
 
         # CloudFormation doesn't seem to properly wait for the job definition name to be properly populated if we allow
         # it to autogenerate it. Generate one which will hopefully not conflict.
-        job_definition_name = f"{endpoint_name}-model-explain-{int(time())}"
+        unique_id = generate_unique_id(
+            clarify_image_uri,
+            endpoint_name,
+            model_bucket_name,
+            model_explainability_checkstep_output_prefix,
+            model_explainability_checkstep_analysis_config_prefix,
+            model_explainability_output_prefix,
+            kms_key_id,
+            model_monitor_role_arn,
+            security_group_id,
+            subnet_ids,
+            instance_count,
+            instance_type,
+            instance_volume_size_in_gb,
+            max_runtime_in_seconds,
+            features_attribute,
+            inference_attribute,
+            probability_attribute,
+            schedule_expression,
+        )
+        job_definition_name = f"{endpoint_name}-model-explain-{unique_id}"
 
         # To match the defaults in SageMaker.
         if model_explainability_checkstep_analysis_config_prefix is None:

--- a/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/model_quality_construct.py
+++ b/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/model_quality_construct.py
@@ -1,8 +1,9 @@
-from time import time
 from typing import Any, List, Optional
 
 from aws_cdk import aws_sagemaker as sagemaker
 from constructs import Construct
+
+from sagemaker_model_monitoring.utils import generate_unique_id
 
 
 class ModelQualityConstruct(Construct):
@@ -41,7 +42,28 @@ class ModelQualityConstruct(Construct):
 
         # CloudFormation doesn't seem to properly wait for the job definition name to be properly populated if we allow
         # it to autogenerate it. Generate one which will hopefully not conflict.
-        job_definition_name = f"{endpoint_name}-model-quality-{int(time())}"
+        unique_id = generate_unique_id(
+            monitor_image_uri,
+            endpoint_name,
+            model_bucket_name,
+            model_quality_checkstep_output_prefix,
+            model_quality_output_prefix,
+            ground_truth_prefix,
+            kms_key_id,
+            model_monitor_role_arn,
+            security_group_id,
+            subnet_ids,
+            instance_count,
+            instance_type,
+            instance_volume_size_in_gb,
+            max_runtime_in_seconds,
+            problem_type,
+            inference_attribute,
+            probability_attribute,
+            probability_threshold_attribute,
+            schedule_expression,
+        )
+        job_definition_name = f"{endpoint_name}-model-quality-{unique_id}"
 
         model_quality_job_definition = sagemaker.CfnModelQualityJobDefinition(
             self,

--- a/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/utils.py
+++ b/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/utils.py
@@ -5,13 +5,5 @@ from typing import Any
 def generate_unique_id(*args: Any) -> str:
     """
     Generate a shortened hex digest from a list of arguments.
-
-    Any non-string arguments are cast to a string.
     """
-    hash = md5()
-    for arg in args:
-        if not isinstance(arg, str):
-            arg = str(arg)
-        hash.update(arg.encode())
-        hash.update(b"\x00")
-    return hash.hexdigest()[:10]
+    return md5(b"\x00".join(str(arg).encode() for arg in args)).hexdigest()[:10]

--- a/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/utils.py
+++ b/modules/sagemaker/sagemaker-model-monitoring/sagemaker_model_monitoring/utils.py
@@ -1,0 +1,17 @@
+from hashlib import md5
+from typing import Any
+
+
+def generate_unique_id(*args: Any) -> str:
+    """
+    Generate a shortened hex digest from a list of arguments.
+
+    Any non-string arguments are cast to a string.
+    """
+    hash = md5()
+    for arg in args:
+        if not isinstance(arg, str):
+            arg = str(arg)
+        hash.update(arg.encode())
+        hash.update(b"\x00")
+    return hash.hexdigest()[:10]


### PR DESCRIPTION
## Describe your changes

Fixes redeploying SageMaker Model Monitoring. Previously if you modified a parameter then CloudFormation would error due to attempting to replace resources (via a create, then delete) using the same name. This adds a timestamp to names so that they'll be unique. Ideally we would allow CloudFormation to generate the names, but this does not seem to work -- CloudFormation is not properly waiting for the job definition to be created before attempting to access the name / propagating it to the monitoring schedule.

The downside of this approach is the monitoring stack will essentially be rebuilt for every update, even if no changes are made. This is double bad since updates will fail if any of the monitoring jobs are running. A potential solution to this could be to use a hash of the input parameters instead of a timestamp.

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I updated `CHANGELOG.MD` with a description of my changes - *not updated since the SageMaker Monitoring module hasn't yet been in a release*
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
