### PR TITLE
limit length of id in model name to prevent model name becoming too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix opensearch removal policy
 - update MWAA to 2.9.2
 - update mwaa constraints
+- limit length of id in model name to prevent model name becoming too long
 
 ## v1.2.0
 

--- a/modules/sagemaker/sagemaker-endpoint/stack.py
+++ b/modules/sagemaker/sagemaker-endpoint/stack.py
@@ -147,7 +147,7 @@ class DeployEndpointStack(Stack):
         self.model_package_arn = model_package_arn
 
         # Create model instance
-        model_name: str = f"{id}-model-{get_timestamp()}"
+        model_name: str = f"{id[:42]}-model-{get_timestamp()}"
         model = sagemaker.CfnModel(
             self,
             "Model",
@@ -195,7 +195,7 @@ class DeployEndpointStack(Stack):
         else:
             data_capture_config = None
 
-        endpoint_config_name: str = f"{id}-conf-{get_timestamp()}"
+        endpoint_config_name: str = f"{id[:42]}-conf-{get_timestamp()}"
         endpoint_config = sagemaker.CfnEndpointConfig(
             self,
             "Endpoint Configuration",


### PR DESCRIPTION
## Describe your changes

Limited the length of id in the model name to 42 characters, to prevent total model name length exceeding 63 characters and causing an exception on deploy.

## Checklist before requesting a review

- [X] I updated `CHANGELOG.MD` with a description of my changes
- [X] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [X] If the change was to a module, I have added thorough tests
- [X] If the change was to a module, I have added/updated the module's README.md
- [X] If a module was added, I added a reference to the module to the repository's README.md
- [X] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
