### PR TITLE
Add permission for get secret value for hf access token secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix opensearch removal policy
 - update MWAA to 2.9.2
 - update mwaa constraints
+- add permission for get secret value in `hf_import_models` template
 
 ## v1.2.0
 

--- a/modules/sagemaker/sagemaker-templates-service-catalog/templates/hf_import_models/pipeline_constructs/build_pipeline_construct.py
+++ b/modules/sagemaker/sagemaker-templates-service-catalog/templates/hf_import_models/pipeline_constructs/build_pipeline_construct.py
@@ -224,6 +224,16 @@ class BuildPipelineConstruct(Construct):
                 resources=[sagemaker_seedcode_bucket.bucket_arn],
             )
         )
+        codebuild_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "secretsmanager:GetSecretValue",
+                ],
+                resources=[
+                    f"arn:aws:secretsmanager:{Aws.REGION}:{Aws.ACCOUNT_ID}:secret:{hf_access_token_secret}-??????"
+                ],
+            )
+        )
 
         # Create the CodeBuild project
         sm_pipeline_build = codebuild.PipelineProject(


### PR DESCRIPTION
## Describe your changes

Added permission for get secret value for hf access token secret to prevent error when using `hf_import_models` template

## Checklist before requesting a review

- [X] I updated `CHANGELOG.MD` with a description of my changes
- [X] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [X] If the change was to a module, I have added thorough tests
- [X] If the change was to a module, I have added/updated the module's README.md
- [X] If a module was added, I added a reference to the module to the repository's README.md
- [X] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
