### PR TITLE
fix: bump ecr module version to consume auto-delete images feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 
+- bump ecr module version to 1.10.0 to consume auto-delete images feature
+
 ## v1.3.0
 
 ### **Added**

--- a/manifests/mlflow-experiments-tracking/storage-modules.yaml
+++ b/manifests/mlflow-experiments-tracking/storage-modules.yaml
@@ -1,5 +1,5 @@
 name: ecr-mlflow
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.7.0&depth=1
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.10.0&depth=1
 targetAccount: primary
 parameters:
   - name: image-tag-mutability

--- a/manifests/mlops-sagemaker-multiacc/storage-modules.yaml
+++ b/manifests/mlops-sagemaker-multiacc/storage-modules.yaml
@@ -1,5 +1,5 @@
 name: ecr-sagemaker-kernel
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.7.0&depth=1
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.10.0&depth=1
 targetAccount: dev
 parameters:
   - name: image-tag-mutability

--- a/manifests/mlops-sagemaker/storage-modules.yaml
+++ b/manifests/mlops-sagemaker/storage-modules.yaml
@@ -1,5 +1,5 @@
 name: ecr-sagemaker-kernel
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.7.0&depth=1
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.10.0&depth=1
 targetAccount: primary
 parameters:
   - name: image-tag-mutability
@@ -12,7 +12,7 @@ parameters:
     value: DESTROY
 ---
 name: buckets
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/buckets?ref=release/1.7.0&depth=1
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/buckets?ref=release/1.10.0&depth=1
 targetAccount: primary
 parameters:
   - name: encryption-type

--- a/manifests/storage-modules.yaml
+++ b/manifests/storage-modules.yaml
@@ -1,5 +1,5 @@
 name: ecr-mlflow
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.7.0&depth=1
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.10.0&depth=1
 targetAccount: primary
 parameters:
   - name: image-tag-mutability
@@ -12,7 +12,7 @@ parameters:
     value: DESTROY
 ---
 name: ecr-sagemaker-kernel
-path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.7.0&depth=1
+path: git::https://github.com/awslabs/idf-modules.git//modules/storage/ecr?ref=release/1.10.0&depth=1
 targetAccount: primary
 parameters:
   - name: image-tag-mutability


### PR DESCRIPTION
## Describe your changes
- Integ testing fails to clean up ECR with images. Auto-delete feature was added in IDF 1.8.0. Bumping to latest.

## Issue ticket number and link

## Checklist before requesting a review

- [] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
