### PR TITLE
Remove Docker bundling in SageMaker model pkg promote pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - increased timeout on finetune_llm_evaluation project from 1 hour (default) to 4 hours
 - pin `ray-operator`, `ray-cluster`, and `ray-image` modules versions
 - pin module versions for all manifests
+- the `sagemaker/sagemaker-model-package-promote-pipeline` module no longer generates a Docker image
 
 ## v1.4.0
 

--- a/modules/sagemaker/sagemaker-model-package-promote-pipeline/images/zip-image/Dockerfile
+++ b/modules/sagemaker/sagemaker-model-package-promote-pipeline/images/zip-image/Dockerfile
@@ -1,3 +1,0 @@
-FROM public.ecr.aws/docker/library/alpine:latest
-
-RUN apk --no-cache add zip make


### PR DESCRIPTION
## Describe your changes

This removes the custom Docker image used for bundling assets in the SageMaker model package promote pipeline stack.

It is unnecessary since the [`s3_assets.Asset` construct can natively zip a directory](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3_assets.Asset.html#path) (emphasis mine):

> **path**: The disk location of the asset.
>
> The path should refer to one of the following:
> * A regular file or a .zip file, in which case the file will be uploaded as-is to S3.
> * *A directory, in which case it will be archived into a .zip file and uploaded to S3.*

We are already providing the directory name as the path so it'll be automatically zipped.

## Issue ticket number and link

Related to #193 as it is removes an image/asset to pull during deployment.

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
