### PR TITLE
fix: pull `ray-ml` image from AWS ECR Public to avoid pull rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added `mlflow-ai-gw-image` module
 
 ### **Changed**
-
+- changed `ray-image` to pull from AWS Public ECR to avoid docker pull rate limits
 
 ## v1.7.0
 

--- a/modules/eks/ray-image/src/Dockerfile
+++ b/modules/eks/ray-image/src/Dockerfile
@@ -1,1 +1,1 @@
-FROM rayproject/ray-ml:2.30.0
+FROM public.ecr.aws/anyscale/ray-ml:2.30.0


### PR DESCRIPTION
## Describe your changes
- pull `ray-ml` image from AWS ECR Public to avoid pull rate limits

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
