### PR TITLE
fix: orchestrator logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 - changed `ray-image` to pull from AWS Public ECR to avoid docker pull rate limits
-- changed `ray-orchestrator` sample script epochs to 0.01 to support demo scenarios
+- changed `ray-orchestrator` to not retrieve full training job logs and avoid `States.DataLimitExceeded`
 
 ## v1.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### **Changed**
 - changed `ray-image` to pull from AWS Public ECR to avoid docker pull rate limits
 - changed `ray-orchestrator` to not retrieve full training job logs and avoid `States.DataLimitExceeded`
+- update `ray-on-eks` manifest cluster resources
 
 ## v1.7.0
 

--- a/manifests/ray-on-eks/core-modules.yaml
+++ b/manifests/ray-on-eks/core-modules.yaml
@@ -44,9 +44,9 @@ parameters:
           eks_node_labels:
             usage: core
         - eks_ng_name: ng-gpu
-          eks_node_quantity: 1
+          eks_node_quantity: 5
           eks_node_max_quantity: 10
-          eks_node_min_quantity: 1
+          eks_node_min_quantity: 5
           eks_node_disk_size: 400
           eks_node_instance_type: "g4dn.4xlarge"
           eks_node_labels:

--- a/manifests/ray-on-eks/ray-cluster-modules.yaml
+++ b/manifests/ray-on-eks/ray-cluster-modules.yaml
@@ -31,11 +31,11 @@ parameters:
   - name: HeadResources
     value:
       requests:
-        cpu: "1"
-        memory: "8G"
+        cpu: "8"
+        memory: "24G"
       limits:
-        cpu: "4"
-        memory: "16G"
+        cpu: "8"
+        memory: "24G"
   - name: WorkerReplicas
     value: 1
   - name: WorkerMinReplicas
@@ -45,8 +45,8 @@ parameters:
   - name: WorkerResources
     value:
       requests:
-        cpu: "4"
-        memory: "8G"
+        cpu: "14"
+        memory: "60G"
       limits:
         cpu: "14"
         memory: "60G"

--- a/modules/eks/ray-orchestrator/ray_orchestrator_stack.py
+++ b/modules/eks/ray-orchestrator/ray_orchestrator_stack.py
@@ -200,7 +200,7 @@ class RayOrchestrator(Stack):
                     "Namespace": namespace_name,
                     "CertificateAuthority": eks_cert_auth_data,
                     "Endpoint": eks_cluster_endpoint,
-                    "LogOptions": {"RetrieveLogs": True},
+                    "LogOptions": {"RetrieveLogs": False},
                     "Job": training_body,
                 },
             },

--- a/modules/eks/ray-orchestrator/scripts/training-6B.py
+++ b/modules/eks/ray-orchestrator/scripts/training-6B.py
@@ -205,7 +205,7 @@ steps_per_epoch = train_ds_size // (batch_size * num_workers)
 trainer = TorchTrainer(
     train_loop_per_worker=train_func,
     train_loop_config={
-        "epochs": 0.01,
+        "epochs": 1,
         "batch_size": batch_size,  # per device
         "steps_per_epoch": steps_per_epoch,
     },


### PR DESCRIPTION
## Describe your changes
- changed `ray-orchestrator` to not retrieve full training job logs and avoid `States.DataLimitExceeded`
- update `ray-on-eks` manifest cluster resources

## Issue ticket number and link

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
