### PR TITLE
Update MWAA dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 - update MWAA to 2.10.1
+- update MWAA dependencies
 
 ## v1.7.1
 

--- a/data/mwaa/requirements/constraint-requirements.txt
+++ b/data/mwaa/requirements/constraint-requirements.txt
@@ -471,7 +471,7 @@ mypy-boto3-redshift-data==1.35.10
 mypy-boto3-s3==1.35.2
 mypy-extensions==1.0.0
 mypy==1.9.0
-mysql-connector-python==9.0.0
+mysql-connector-python==9.1.0
 mysqlclient==2.2.4
 nbclient==0.10.0
 nbformat==5.10.4
@@ -638,7 +638,7 @@ smbprotocol==1.14.0
 smmap==5.0.1
 sniffio==1.3.1
 snowballstemmer==2.2.0
-snowflake-connector-python==3.12.1
+snowflake-connector-python==3.12.3
 snowflake-sqlalchemy==1.6.1
 sortedcontainers==2.4.0
 soupsieve==2.6


### PR DESCRIPTION
## Describe your changes

Bump version for `mysql-connector-python` and `snowflake-connector-python` to resolve vulnerabilities. Versions were previously bumped in #259 and #260 but were downgraded in #267 due to using the [generated constraint file](https://raw.githubusercontent.com/apache/airflow/constraints-2.10.1/constraints-3.11.txt) from apache

## Checklist before requesting a review

- [X] I updated `CHANGELOG.MD` with a description of my changes
- [X] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [X] If the change was to a module, I have added thorough tests
- [X] If the change was to a module, I have added/updated the module's README.md
- [X] If a module was added, I added a reference to the module to the repository's README.md
- [X] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
