### PR TITLE
fix: ground truth log group name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 - fixed notebook name lengths in `sagemaker-notebook` module
+- fixed log group name  in `sagemaker-ground-truth` module
 
 ## v1.8.0
 

--- a/modules/sagemaker/sagemaker-ground-truth-labeling/labeling_step_function/labeling_state_machine.py
+++ b/modules/sagemaker/sagemaker-ground-truth-labeling/labeling_step_function/labeling_state_machine.py
@@ -788,7 +788,7 @@ def create_state_machine(
     state_machine_log_group = logs.LogGroup(
         scope,
         "StateMachineLogGroup",
-        log_group_name=f"{id}-state-machine",
+        log_group_name=f"/aws/vendedlogs/states/{job_name}",
         retention=logs.RetentionDays.ONE_MONTH,
         removal_policy=RemovalPolicy.DESTROY,
     )


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

Fixes:

```
Resource handler returned message: "Invalid Logging Configuration: The CloudWatch Logs Resource Policy size was exceeded. We suggest prefixing your CloudWatch log group name with /aws/vendedlogs/states/. (Service: Sfn, Status Code: 400, Request ID: <REDACTED>) (SDK Attempt Count: 1)" (RequestToken: <REDACTED>, HandlerErrorCode: InvalidRequest)

```

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
