### PR TITLE
chore: update seedfarmer version & set base image to AL2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed notebook name lengths in `sagemaker-notebook` module
 - fixed log group name  in `sagemaker-ground-truth` module
 - updated cdk cli versions
+- updated seedfarmer version (WARNING: uses AL2023 base image)
+- remove gettext-base dependency from `sagemaker-studio` module (fixes install with AL2023 base image)
+- fix add explicit boto3 dependency to `sagemaker-custom-kernels` module
 
 ## v1.8.0
 

--- a/manifests/mlops-sagemaker/deployment.yaml
+++ b/manifests/mlops-sagemaker/deployment.yaml
@@ -17,6 +17,7 @@ targetAccountMappings:
     accountId:
       valueFrom:
         envVariable: PRIMARY_ACCOUNT
+    codebuildImage: aws/codebuild/standard:7.0
     default: true
     regionMappings:
       - region: us-east-1

--- a/manifests/mlops-sagemaker/kernels-modules.yaml
+++ b/manifests/mlops-sagemaker/kernels-modules.yaml
@@ -1,5 +1,5 @@
 name: sagemaker-custom-kernel
-path: git::https://github.com/awslabs/aiops-modules.git//modules/sagemaker/sagemaker-custom-kernel?ref=release/1.8.0&depth=1
+path: modules/sagemaker/sagemaker-custom-kernel
 targetAccount: primary
 parameters:
   - name: ecr-repo-name

--- a/modules/sagemaker/sagemaker-custom-kernel/requirements.txt
+++ b/modules/sagemaker/sagemaker-custom-kernel/requirements.txt
@@ -4,3 +4,4 @@ cdk-nag==2.12.29
 cdk-ecr-deployment==3.0.43
 pydantic==2.7.2
 pydantic-settings==2.2.1
+boto3

--- a/modules/sagemaker/sagemaker-studio/deployspec.yaml
+++ b/modules/sagemaker/sagemaker-studio/deployspec.yaml
@@ -5,7 +5,6 @@ deploy:
       commands:
         - npm install -g aws-cdk@2.178.2
         - pip install -r requirements.txt
-        - apt-get install gettext-base
     build:
       commands:
         - LCC_CONTENT=`openssl base64 -A -in scripts/on-jupyter-server-start.sh`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-seed-farmer~=5.0.0
+seed-farmer~=7.0.5


### PR DESCRIPTION
## Describe your changes
- updated seedfarmer version (WARNING: uses AL2023 base image)
- set base image as AL2023 explicitly
- remove gettext-base dependency from `sagemaker-studio` module (fixes install with AL2023 base image)
- fix add explicit boto3 dependency to `sagemaker-custom-kernels` module
- changelog

## Testing

<img width="832" height="186" alt="image" src="https://github.com/user-attachments/assets/6dcddb49-3483-4e72-8c54-d0ff819c4d63" />

## Checklist before requesting a review

- [x] I updated `CHANGELOG.MD` with a description of my changes
- [x] If the change was to a module, I ran the code validation script (`scripts/validate.sh`)
- [x] If the change was to a module, I have added thorough tests
- [x] If the change was to a module, I have added/updated the module's README.md
- [x] If a module was added, I added a reference to the module to the repository's README.md
- [x] I verified that my code deploys successfully using `seedfarmer apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
