### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/module-checks.yml
+++ b/.github/workflows/module-checks.yml
@@ -1,4 +1,6 @@
 name: Module Checks
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/awslabs/aiops-modules/security/code-scanning/12](https://github.com/awslabs/aiops-modules/security/code-scanning/12)

To fix the issue, we should set a `permissions` block to restrict the default permissions of the GITHUB_TOKEN for the workflow or for individual jobs. Since neither job requires permissions beyond reading repository contents (no write operations, no interactions with issues, PRs, or packages), the best practice is to add the permissions block at the top level, so it applies to all jobs unless overridden. Add the following block after the workflow `name:` and before the `on:` trigger:

```yaml
permissions:
  contents: read
```

This addition ensures the GITHUB_TOKEN only has read access to repository contents, preventing unintended privilege escalation or security risks. No imports or new methods are required, as this change is only in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
