### PR TITLE
fix: Code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-integration-tests.yml
+++ b/.github/workflows/check-integration-tests.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   get-modules:
     name: Get Modules
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.get-modules.outputs.matrix }}


### PR DESCRIPTION
Potential fix for [https://github.com/awslabs/aiops-modules/security/code-scanning/7](https://github.com/awslabs/aiops-modules/security/code-scanning/7)

To resolve this, add a minimal `permissions` block to the `get-modules` job, specifying `contents: read`. This ensures the GITHUB_TOKEN used in the job has only the minimum necessary permission to read repository contents, preventing any accidental or malicious write access.

Specifically, edit the `.github/workflows/check-integration-tests.yml` file:
- Locate the `get-modules` job definition (starts at line 9).
- Add the following block between lines 10 (`name: Get Modules`) and 11 (`runs-on: ubuntu-latest`):

  ```yaml
      permissions:
        contents: read
  ```

No additional imports or method changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
